### PR TITLE
Fixed a bug with Force Passenger Mount button.

### DIFF
--- a/Bestride_Logic.lua
+++ b/Bestride_Logic.lua
@@ -87,7 +87,7 @@ function Bestride:BuildPassengerTable(mountType)
   
 	for k,v in pairs(BestrideType["Passenger"]) do
 		local mountIndex = self.db.profile.mounts[k][3]
-		if Bestride:IsUsableMount(mountIndex) and v == mountType then
+		if mountIndex and Bestride:IsUsableMount(mountIndex) and v == mountType then
 			e[i] = k
 			i = i + 1
 		end
@@ -97,7 +97,7 @@ function Bestride:BuildPassengerTable(mountType)
 	if #e == 0 then
 		for k,v in pairs(BestrideType["Passenger"]) do
 			local mountIndex = self.db.profile.mounts[k][3]
-			if Bestride:IsUsableMount(mountIndex) then
+			if mountIndex and Bestride:IsUsableMount(mountIndex) then
 				e[i] = k
 				i = i + 1
 			end


### PR DESCRIPTION
Simple fix for #5, where an error was being thrown when pressing the "Force Passenger Mount" key.

The BestrideType["Passenger"] table contains the spell ids for potential passenger mounts, but the mount index is needed to check if the mount is usable.
The code expects to retrieve this information from the profile data, but if the player does not own one of the passenger mounts, the information is not present there, and mountIndex becomes nil. This eventually causes an error after the value has been passed to IsUsableMount.