### PR TITLE
Add Blizzcon 2017 Passenger mounts

### DIFF
--- a/Bestride_Data.lua
+++ b/Bestride_Data.lua
@@ -27,6 +27,8 @@ BestrideType = {
 		[75973] = "fly", --X-53 Touring Rocket
 		[93326] = "fly", --Sandstone Drake
 		[121820] = "fly", --Obsidian Nightwing
+		[245725] = "fly", --Orgrimmar Interceptor
+		[245723] = "fly", -- Stormwind Skychaser
 	},
 	["Mounts"] = {
 		[230] = "ground", -- Ground mounts


### PR DESCRIPTION
This adds the [Orgrimmar Interceptor](http://www.wowhead.com/spell=245725/orgrimmar-interceptor) and the [Stormwind Skychaser](http://www.wowhead.com/spell=245723/stormwind-skychaser) to the list of passenger mounts.
These are two-seater flying mounts.